### PR TITLE
erofsnightly: add ocierofs smoke testing

### DIFF
--- a/.github/workflows/ocierofs.yml
+++ b/.github/workflows/ocierofs.yml
@@ -1,0 +1,63 @@
+name: ocierofs
+
+on:
+  schedule:
+    # run at CST 9:00 and 21:00
+    - cron:  '0 1,13 * * *'
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-erofs-utils:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build erofs-utils
+        run: |
+          sudo apt -qq update
+          sudo apt-get install -y libfuse-dev libselinux1-dev libcurl4-openssl-dev libjson-c-dev
+          curl -L https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz | tar -zxv
+          make BUILD_SHARED=no -C lz4-1.9.4 && lz4libdir=$(pwd)/lz4-1.9.4/lib
+          git clone https://github.com/erofs/erofs-utils.git -b experimental
+          cd erofs-utils
+          mkdir output
+          ./autogen.sh && ./configure --enable-debug --enable-werror --enable-fuse --with-selinux \
+              --enable-oci --with-libcurl --with-json-c \
+              --prefix=$(pwd)/output \
+              --with-lz4-incdir=${lz4libdir} --with-lz4-libdir=${lz4libdir} && \
+              make && make install
+      - name: Upload erofs-utils
+        uses: actions/upload-artifact@v4
+        with:
+          name: erofs-utils
+          path: |
+            erofs-utils/output
+
+  erofsfuse-oci-smoking:
+    runs-on: ubuntu-22.04
+    needs: build-erofs-utils
+    strategy:
+      matrix:
+        pass: [0, 1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download erofs-utils prebuilts
+        uses: actions/download-artifact@v4
+        with:
+          name: erofs-utils
+      - name: Verify image built from OCI
+        run: |
+          sudo apt -qq update
+          sudo apt-get install -y libfuse2 fuse-overlayfs libssl-dev skopeo
+          chmod +x bin/mkfs.erofs bin/fsck.erofs bin/erofsfuse
+          ./erofsfuse-oci-test ${{ matrix.pass }} docker.io/library/alpine:latest
+      - name: Upload images if the test fails
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: erofsfuse-oci-images
+          path: '*.img'

--- a/erofsfuse-oci-test
+++ b/erofsfuse-oci-test
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -e
+
+[ "$1" -eq 1 ] && args='-zlz4hc,12'
+if [ "$1" -eq 2 ]; then
+	blks=$((RANDOM % 255 + 2))
+	echo "EROFS pclusterblks=$blks"
+	args="-zlz4hc,12 -C$((blks*4096)) --random-pclusterblks"
+fi
+if [ "$1" -eq 3 ]; then
+	chunksize=$((4096 << (RANDOM % 11)))
+	echo "EROFS chunksize=$chunksize (blockmap)"
+	args="--chunksize $chunksize -Eforce-inode-blockmap"
+fi
+if [ "$1" -eq 4 ]; then
+	chunksize=$((4096 << (RANDOM % 11)))
+	echo "EROFS chunksize=$chunksize (chunkindexes)"
+	args="--chunksize $chunksize -Eforce-chunk-indexes"
+fi
+[ "$1" -eq 5 ] && args='-zdeflate,9'
+if [ "$1" -eq 6 ]; then
+	blks=$((RANDOM % 255 + 2))
+	echo "EROFS DEFLATE pclusterblks=$blks"
+	args="-zdeflate,9 -C$((blks*4096)) --random-pclusterblks"
+fi
+
+# OCI image name (default to alpine if not specified)
+OCI_IMAGE="${2:-alpine:latest}"
+echo "Testing OCI image: $OCI_IMAGE"
+
+# Cleanup function
+cleanup() {
+	echo "Cleaning up..."
+	fusermount -u oci-erofs-mount 2>/dev/null || true
+	rm -rf oci-reference oci-erofs-mount oci-image.tar oci-temp
+}
+
+trap cleanup EXIT
+
+# Step 1: Download OCI image and extract as reference
+skopeo copy "docker://$OCI_IMAGE" docker-archive:oci-image.tar
+
+# Step 2: Extract OCI image structure
+mkdir -p oci-temp
+tar -xf oci-image.tar -C oci-temp
+
+# Step 3: Find and extract the first layer (layer 0)
+mkdir -p oci-reference
+
+# Find the first layer tar from manifest
+FIRST_LAYER=$(jq -r '.[0].Layers[0]' oci-temp/manifest.json)
+
+# Extract the layer tar to get actual filesystem
+tar -xf "oci-temp/$FIRST_LAYER" -C oci-reference
+
+# Clean up OCI temp structure
+rm -rf oci-temp
+
+# Step 4: Build EROFS image from OCI
+bin/mkfs.erofs --force-uid="$(id -u)" --force-gid="$(id -g)" $args --oci=f oci.erofs.img $OCI_IMAGE
+
+bin/fsck.erofs oci.erofs.img || exit 1
+mkdir -p oci-erofs-mount
+bin/erofsfuse oci.erofs.img oci-erofs-mount
+
+# Step 5: Verify contents by comparing hashes
+ref_hash=$(tar --sort=name --mode=0777 --owner=0 --group=0 --mtime='@0' --clamp-mtime -C oci-reference -cf - . | sha256sum | awk '{print $1}')
+echo "Reference hash: $ref_hash"
+erofs_hash=$(tar --sort=name --mode=0777 --owner=0 --group=0 --mtime='@0' --clamp-mtime -C oci-erofs-mount -cf - . | sha256sum | awk '{print $1}')
+echo "EROFS hash: $erofs_hash"
+
+# Compare hashes
+if [ "$ref_hash" = "$erofs_hash" ]; then
+	echo "✓ Hash verification PASSED - directories are identical!"
+else
+	echo "✗ ERROR: Hash mismatch!"
+	echo "  Reference: $ref_hash"
+	echo "  EROFS:     $erofs_hash"
+	exit 1
+fi


### PR DESCRIPTION
This PR add simple smoking tests covering newly added `mkfs.erofs --oci=` interface by comparing files.