### PR TITLE
qemu-kbuild: genrootfs: upgrade Debian version to trixie

### DIFF
--- a/genrootfs.sh
+++ b/genrootfs.sh
@@ -20,7 +20,7 @@ PACKAGES=$(echo $PACKAGES | sed 's/ /,/g')
 
 apt-get install -y debootstrap
 mkdir -p $ROOTDIR
-debootstrap --variant=minbase --include=$PACKAGES buster $ROOTDIR $MIRROR
+debootstrap --variant=minbase --include=$PACKAGES trixie $ROOTDIR $MIRROR
 tar -C kbuild-overlay \
 	--owner=root --group=root --mode=go+u-w -c . | tar -C $ROOTDIR -x
 run_in_chroot "systemctl disable systemd-timesyncd"

--- a/qemu-kbuild-test
+++ b/qemu-kbuild-test
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-mem="768M"
+mem="1G"
 
 [ "$3" -eq 1 ] && args='-zlz4hc,12'
 if [ "$3" -eq 2 ]; then
 	blks=$((RANDOM % 255 + 2))
 	echo "EROFS pclusterblks=$blks"
 	args="-zlz4hc,12 -C$((blks*4096)) --random-pclusterblks"
-	mem="1G"
-	[ $blks -gt 171 ] && mem="1280M"
+	mem="1152M"
+	[ $blks -gt 171 ] && mem="1408M"
 fi
 if [ "$3" -eq 3 ]; then
 	chunksize=$((4096 << (RANDOM % 11)))
@@ -25,11 +25,11 @@ if [ "$3" -eq 6 ]; then
 	blks=$((RANDOM % 255 + 2))
 	echo "EROFS pclusterblks=$blks"
 	args="-zzstd -C$((blks*4096)) --random-pclusterblks"
-	mem="1G"
-	[ $blks -gt 171 ] && mem="1280M"
+	mem="1152M"
+	[ $blks -gt 171 ] && mem="1408M"
 fi
-curl https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.4.140.tar.gz | tar -zx
-bin/mkfs.erofs $args linux.erofs.img linux-5.4.140 && rm -rf linux-5.4.140
+curl https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.63.tar.xz | tar -Jx
+bin/mkfs.erofs $args linux.erofs.img linux-6.12.63 && rm -rf linux-6.12.63
 bin/fsck.erofs linux.erofs.img || exit 1
 fallocate -l 11g overlay.ext4.img && mkfs.ext2 -q overlay.ext4.img
 sync


### PR DESCRIPTION
The Debian 10 “Buster” end-of-life has been reached, and it has been removed from mirrors.kernel.org. This patch migrates the VM rootfs build process—currently dependent on Buster—to Debian 13 “Trixie”, and correspondingly increases the VM memory size needed for testing.

The job has been tested and runs successfully [1], but the runtime has slightly increased (>3 hours).

[1] https://github.com/SToPire/erofsnightly/actions/runs/20514965285/job/58941285928