### PR TITLE
test: add block map and blobdev compatibility test

### DIFF
--- a/.github/workflows/smoking.yml
+++ b/.github/workflows/smoking.yml
@@ -222,3 +222,25 @@ jobs:
           bin/erofsfuse enwik8.zstd.erofs out
           [ $(md5sum out/enwik8 | cut -d' ' -f1) != $goldenmd5 ] && false
           fusermount -u out && rm -rf enwik8.zstd.erofs
+        
+  blobdev-bmap-smoking:
+    runs-on: ubuntu-22.04
+    needs: build-erofs-utils
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download erofs-utils prebuilts
+        uses: actions/download-artifact@v4
+        with:
+          name: erofs-utils
+      - name: blobdev and block map compatibility testing
+        run: |
+          sudo apt -qq update
+          sudo apt-get install -y libfuse2
+          chmod +x bin/mkfs.erofs bin/fsck.erofs bin/erofsfuse blobdev-bmap-test
+          ./blobdev-bmap-test
+      - name: Upload images if the test fails
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: blobdev-bmap-images
+          path: '*.img'

--- a/blobdev-bmap-test
+++ b/blobdev-bmap-test
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+echo "=========================================="
+echo "Testing mkfs.erofs with --blobdev and block map"
+echo "=========================================="
+
+cleanup() {
+    fusermount -u mnt 2>/dev/null || true
+    rm -rf test-source extract-dir mnt test.erofs.img test.blob.img
+}
+trap cleanup EXIT
+
+mkdir -p test-source extract-dir mnt
+dd if=/dev/urandom of=test-source/large_file.bin bs=1M count=2 status=none
+echo "Hello EROFS Block Map" > test-source/small_file.txt
+
+if ! bin/mkfs.erofs -E force-inode-blockmap --chunksize=4096 --blobdev=test.blob.img test.erofs.img test-source/; then
+    echo "ERROR: mkfs.erofs failed"
+    exit 1
+fi
+
+if ! bin/fsck.erofs --device=test.blob.img test.erofs.img; then
+    echo "ERROR: fsck.erofs failed to verify the image"
+    exit 1
+fi
+
+if ! bin/erofsfuse --device=test.blob.img test.erofs.img mnt; then
+    echo "ERROR: erofsfuse failed to mount the image"
+    exit 1
+fi
+
+if ! diff -r --no-dereference test-source/ mnt/; then
+    echo "ERROR: Content mismatch! Data read from blob device is corrupted."
+    exit 1
+fi
+
+echo "=========================================="
+echo "ALL TESTS PASSED for blobdev + block map"
+echo "=========================================="
+exit 0


### PR DESCRIPTION
This PR adds a new test script (`blobdev-bmap-test`) to verify the compatibility between the `--blobdev` flag and the block map chunk format (`-E force-inode-blockmap`). 

This test specifically validates the [`[PATCH v2] mkfs: support block map for blob devices`](https://lore.kernel.org/linux-erofs/20260309122434.49204-1-nithurshen.dev@gmail.com/) patch recently submitted to the `linux-erofs` mailing list.

**What this test does:**
* Generates a chunked EROFS image with extra devices using `mkfs.erofs --blobdev`.
* Verifies image integrity and tests userspace device mapping logic via `fsck.erofs`.
* Tests mounting and reading from the extra blob device using `erofsfuse`.
* Integrates the new test into the `basicsmoking` GitHub Actions workflow (`smoking.yml`).

Signed-off-by: Nithurshen <nithurshen.dev@gmail.com>