### PR TITLE
Update mount test image reference and fix libnl3 runtime issue

### DIFF
--- a/.github/workflows/mount.yml
+++ b/.github/workflows/mount.yml
@@ -29,7 +29,7 @@ jobs:
           git clone ${{ vars.EROFSUTILS_SOURCE_URL || 'https://github.com/erofs/erofs-utils' }} -b experimental erofs-utils
           cd erofs-utils
           mkdir output
-          libnl3_flag=""
+          libnl3_flag="--without-libnl3"
           if [ "${{ matrix.libnl3 }}" = "true" ]; then
             libnl3_flag="--with-libnl3"
           fi
@@ -59,6 +59,12 @@ jobs:
             build_with_libnl3: false
           - test_type: local
             runtime_libnl3: false
+          - test_type: nbdlocal
+            build_with_libnl3: true
+            runtime_libnl3: false
+          - test_type: nbdoci
+            build_with_libnl3: true
+            runtime_libnl3: false
     steps:
       - uses: actions/checkout@v4
       - name: Download erofs-utils prebuilts (build=${{ matrix.build_with_libnl3 == true && 'with-nl' || 'wo-nl' }}, runtime=${{ matrix.runtime_libnl3 == true && 'with-nl' || 'wo-nl' }})
@@ -74,6 +80,9 @@ jobs:
           sudo apt-get install -y libfuse2 fuse-overlayfs libssl-dev
           if [ "${{ matrix.runtime_libnl3 }}" = "true" ]; then
             sudo apt-get install -y libnl-3-200 libnl-genl-3-200
+          else
+            sudo apt-get purge -y libnl-3-200 libnl-genl-3-200
+            sudo apt-get autoremove -y --purge
           fi
           if [[ "${{ matrix.test_type }}" == nbd* ]]; then
             sudo modprobe nbd

--- a/mount-test
+++ b/mount-test
@@ -2,10 +2,10 @@
 
 set -ex
 
-OCI_IMAGE="ghcr.io/erofs/alpine:3.23.2"
-EROFS_IMAGE="ghcr.io/erofs/alpine:3.23.2-erofs"
-EROFS_IMAGE_MULTILAYER="ghcr.io/erofs/nginx:1.28.1-alpine-erofs"
-NONEXISTENT_IMAGE="ghcr.io/erofs/nonexistent-image-12345:latest"
+OCI_IMAGE="ghcr.io/erofslabs/alpine:3.23.2"
+EROFS_IMAGE="ghcr.io/erofslabs/alpine:3.23.2-erofs"
+EROFS_IMAGE_MULTILAYER="ghcr.io/erofslabs/nginx:1.28.1-alpine-erofs"
+NONEXISTENT_IMAGE="ghcr.io/erofslabs/nonexistent-image-12345:latest"
 
 # Test type (required: local, nbdlocal, or nbdoci)
 TEST_TYPE="${1}"


### PR DESCRIPTION
This PR updates OCI image reference for the mount workflow.

Also fixes a bug in the mount workflow where the “without libnl3” case was not actually being exercised on GitHub Actions. Currently `libnl3` runtime always exists in the runner. The workflow now builds the (without-nl) artifact with `--without-libnl3`, purges the libnl runtime packages before running the `runtime=false` jobs, and removes the invalid `build=true, runtime=false` matrix entries.