### PR TITLE
erofsnightly: fix fuzz artifact prefix

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -90,7 +90,7 @@ jobs:
           chmod +x bin/fuzz_erofsfsck
           mkdir -p artifacts
           ulimit -s 32768
-          bin/fuzz_erofsfsck -fork=2 -artifact_prefix=./artifacts -timeout=40 -max_total_time=600 -timeout_exitcode=0 corpus_dir
+          bin/fuzz_erofsfsck -fork=2 -artifact_prefix=./artifacts/ -timeout=40 -max_total_time=600 -timeout_exitcode=0 corpus_dir
       - name: Upload artifacts if tests fail
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Previously `-artifact_prefix=./artifacts` wrote failing inputs as `./artifactscrash-*`, and upload-artifact step did not include them.

Add missing slash so fuzzing failures land in the uploaded directory.

Assisted-by: CodeX:GPT-5.5