### PR TITLE
qemu-kbuild-test: exit qemu on guest panic

### DIFF
--- a/qemu-kbuild-test
+++ b/qemu-kbuild-test
@@ -34,11 +34,11 @@ bin/fsck.erofs linux.erofs.img || exit 1
 fallocate -l 11g overlay.ext4.img && mkfs.ext2 -q overlay.ext4.img
 sync
 qemu-system-x86_64 -nographic -serial mon:stdio -m $mem -smp 4 \
-	--accel tcg,thread=multi -kernel $1 \
+	--accel tcg,thread=multi -no-reboot -kernel $1 \
 	-drive file=$2,index=0,readonly,media=cdrom \
 	-hdb linux.erofs.img -hdc overlay.ext4.img \
 	-net nic,model=e1000 -net user \
-	-append "net.ifnames=0 root=/dev/sr0 console=ttyS0"
+	-append "net.ifnames=0 root=/dev/sr0 console=ttyS0 panic=1"
 
 mkdir mnt && sudo mount -o loop overlay.ext4.img mnt && \
 	{ [ -f mnt/exitstatus ] && [ "x`cat mnt/exitstatus`" = "x0" ]; }


### PR DESCRIPTION
Make QEMU exit immediately after a guest kernel panic so CI fails promptly instead of hanging until timeout.

Timeout Example:https://github.com/erofslabs/erofsnightly/actions/runs/26354235424/job/77583175190