### PR TITLE
erofsnightly: suppress fuzzer memory-limit reports

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -90,7 +90,9 @@ jobs:
           chmod +x bin/fuzz_erofsfsck
           mkdir -p artifacts
           ulimit -s 32768
-          bin/fuzz_erofsfsck -fork=2 -artifact_prefix=./artifacts/ -timeout=40 -max_total_time=600 -timeout_exitcode=0 corpus_dir
+          bin/fuzz_erofsfsck -fork=2 -artifact_prefix=./artifacts/ \
+            -timeout=40 -max_total_time=600 -timeout_exitcode=0 \
+            -rss_limit_mb=0 -malloc_limit_mb=0 corpus_dir
       - name: Upload artifacts if tests fail
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Crafted EROFS images can encode metadata that leads fsck.erofs to request
very large allocations. In normal execution these allocations are rejected by
libc/the OS with -ENOMEM, and the existing error paths handle that as a regular
filesystem corruption/error case.

This is not a memory-safety failure, but libFuzzer currently treats the large
allocation request itself as an OOM finding and fails the nightly fuzz job,
creating false positives. Examples:

  - https://github.com/erofslabs/erofsnightly/actions/runs/27669954952/job/81861913212
  - https://github.com/erofslabs/erofsnightly/actions/runs/27740086066/job/82092435186

Disable libFuzzer's RSS and malloc limits for the fsck.erofs fuzzer so these
malformed images remain useful corpus inputs without being reported as fuzzing
failures.